### PR TITLE
chore: add davidgasquez and kasteph to fil-flow pull

### DIFF
--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -86,7 +86,7 @@ repositories:
       pull:
         - davidgasquez
         - kasteph
-  description: Visualising token flows.
+    description: Visualising token flows.
     teams:
       admin:
         - w3dt-stewards

--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -83,7 +83,10 @@ repositories:
         - placer14
         - willscott
         - zixuanzh
-    description: Visualising token flows.
+      pull:
+        - davidgasquez
+        - kasteph
+  description: Visualising token flows.
     teams:
       admin:
         - w3dt-stewards


### PR DESCRIPTION
<!-- Please explain the reason for this change. -->

@davidgasquez and myself need read access to fil-flow since one of the schemas we maintain on Sentinel is dependent on the mapping of SP IDs <> human readable names.
