### PR TITLE
Grant maintainer access to `index-observer`

### DIFF
--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -277,9 +277,9 @@ repositories:
       admin:
         - willscott
       maintain:
-        - masih
-        - ischasny
         - gammazero
+        - ischasny
+        - masih
       push:
         - sti-bot
     default_branch: main

--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -278,6 +278,8 @@ repositories:
         - willscott
       maintain:
         - masih
+        - ischasny
+        - gammazero
       push:
         - sti-bot
     default_branch: main


### PR DESCRIPTION


### Summary
Grant bedrock dev team maintainer access to index-observer.

### Why do you need this?
So that someone in the team can review my PR in the absence of repo admin.

### What else do we need to know?
That's it.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
