### PR TITLE
Add `masih` as admin of `indexstar`

### DIFF
--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -290,6 +290,7 @@ repositories:
     collaborators:
       admin:
         - willscott
+        - masih
       maintain:
         - davidd8
         - ischasny

--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -289,8 +289,8 @@ repositories:
   indexstar:
     collaborators:
       admin:
-        - willscott
         - masih
+        - willscott
       maintain:
         - davidd8
         - ischasny


### PR DESCRIPTION
Needed as part of tranfering repos to dedicated GitHub org.

### Summary
Add `masih` as admin of `indexstar`

### Why do you need this?
Needed as part of tranfering repos to dedicated GitHub org.

### What else do we need to know?
Nothing elese.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
