### PR TITLE
Remove `masih` as maintainer of indexstar

### DIFF
--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -294,7 +294,6 @@ repositories:
       maintain:
         - davidd8
         - ischasny
-        - masih
       push:
         - gammazero
         - sti-bot


### PR DESCRIPTION
Earlier PR made `masih` admin of that repo which doesn't seem to take effect. Check this is not caused by the user also appearing under `maintain`.

### Summary
<!-- include a short summary of the request -->

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
