### PR TITLE
Give `masih` write access to programmatic permission management

### DIFF
--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -1023,6 +1023,7 @@ teams:
       #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
       member:
+        - masih
         - rvagg
         - willscott
     privacy: closed


### PR DESCRIPTION



### Summary
Allow `masih` to open PRs against github management repo.

### Why do you need this?
To avoid working on a fork of this repo and be able to open branches directly.

### What else do we need to know?

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
