### PR TITLE
Give gammazero filecoin-shipyard membership and rockbed admin

### DIFF
--- a/github/filecoin-shipyard.yml
+++ b/github/filecoin-shipyard.yml
@@ -13,6 +13,7 @@ members:
     - andyschwab
     - arajasek
     - brunolm
+    - gammazero
     - jimmylee
     - jimpick
     - lexluthr
@@ -952,6 +953,7 @@ repositories:
         lock_branch: false
     collaborators:
       admin:
+        - gammazero
         - masih
     default_branch: main
     description: End to end test for all things Filecoin
@@ -1102,6 +1104,7 @@ teams:
       #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
       member:
+        - gammazero
         - masih
         - rvagg
         - willscott


### PR DESCRIPTION
### Summary
Gammazero needs to be able to contrbute to repos in filecoin-shipyard. Gammazero needs to be able to create branches and modify PRs in rockbed.

### Why do you need this?
To work on filecoin and motion repos that live in filecoin-shipyard

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
